### PR TITLE
use v4 API version

### DIFF
--- a/teslamonitor.py
+++ b/teslamonitor.py
@@ -97,7 +97,7 @@ queryJson = {
 
 queryString = json.dumps(queryJson)
 
-url = 'https://www.tesla.com/inventory/api/v1/inventory-results?query=' + urllib.parse.quote(queryString)
+url = 'https://www.tesla.com/inventory/api/v4/inventory-results?query=' + urllib.parse.quote(queryString)
 
 print(url)
 headers = {}


### PR DESCRIPTION
Uses the `v4` API for the standard `selenium.py` script. The V1 API url does not seem to work, and the `*selenium` script uses this URL, so I assume this is safe.

Example repro URL: https://www.tesla.com/inventory/api/v4/inventory-results?query=%7B%22query%22%3A%20%7B%22model%22%3A%20%22my%22%2C%20%22condition%22%3A%20%22new%22%2C%20%22options%22%3A%20%7B%22TRIM%22%3A%20%5B%22LRAWD%22%5D%2C%20%22WHEELS%22%3A%20%5B%22NINETEEN%22%5D%7D%2C%20%22arrangeby%22%3A%20%22Price%22%2C%20%22order%22%3A%20%22asc%22%2C%20%22market%22%3A%20%22US%22%2C%20%22language%22%3A%20%22en%22%2C%20%22super_region%22%3A%20%22north%20america%22%2C%20%22zip%22%3A%20%2294121%22%2C%20%22range%22%3A%20200%7D%2C%20%22offset%22%3A%200%2C%20%22count%22%3A%2050%2C%20%22outsideOffset%22%3A%200%2C%20%22outsideSearch%22%3A%20false%7D